### PR TITLE
vehicleTurretCombo logic fix

### DIFF
--- a/Halo Online Projectile Editor/Form1.cs
+++ b/Halo Online Projectile Editor/Form1.cs
@@ -288,7 +288,7 @@ namespace Halo_Online_Projectile_Editor
                 armorLabel.Enabled = true;
                 propLabel.Enabled = true;
                 vehiclesLabel.Enabled = true;
-                vehicleTurretCombo.Enabled = true;
+                vehicleTurretCombo.Enabled = (vehiclesCombo.SelectedItem != null && VehicleTurretHandler.accept_list.Contains((string)vehiclesCombo.SelectedItem));
                 vehicleTurretLabel.Enabled = true;
             }
             else


### PR DESCRIPTION
The vehicle turret combo box should only be enabled if a valid vehicle is selected.