### PR TITLE
Bug Fix for Allow Custom Projectiles Checkbox

### DIFF
--- a/Halo Online Projectile Editor/Form1.cs
+++ b/Halo Online Projectile Editor/Form1.cs
@@ -330,6 +330,7 @@ namespace HaloOnlineTrainer
             if (mapCheck.Checked)
             {
                 GenericHandler.ResetProjectile();
+                spawnCombo.Text = "Fire Weapon";
                 projectileCombo.Text = "";
                 weaponsCombo.Text = "";
                 vehiclesCombo.Text = "";
@@ -363,8 +364,11 @@ namespace HaloOnlineTrainer
             {
                 GenericHandler.ResetProjectile();
                 sg_prev = 0x0001AD;
-                GenericHandler.SetNewProjectile(sg_prev, sg_address);
-                sg_address = 0xB5DBA5;
+                if (sg_address != 0xB5DBA5){
+                    GenericHandler.SetNewProjectile(sg_prev, sg_address);
+                    sg_address = 0xB5DBA5;
+                }
+                spawnCombo.Text = "Fire Weapon";
                 projectileCombo.Text = "";
                 weaponsCombo.Text = "";
                 vehiclesCombo.Text = "";


### PR DESCRIPTION
+Previously if you selected "Throw a grenade" to spawn and then disabled and enabled "Allow Custom Projectiles" the gun would be set up to spawn but the combo box would still show "Throw a grenade". Setting the combo text to default to "Fire Weapon" on check/uncheck fixes this.

+Only resets the grenade if an address for the grenade has been found (otherwise the gun will shoot grenades).